### PR TITLE
enabling toggle button for nodes having children loaded at runtime

### DIFF
--- a/node-content-renderer.js
+++ b/node-content-renderer.js
@@ -91,12 +91,10 @@ class FileThemeNodeContentRenderer extends Component {
         );
       }
     });
-
+    const buttonRenderFlag = toggleChildrenVisibility && (node.children && node.children.length > 0) || node.asyncChildren
     const nodeContent = (
       <div style={{ height: '100%' }} {...otherProps}>
-        {toggleChildrenVisibility &&
-          node.children &&
-          node.children.length > 0 && (
+        {buttonRenderFlag && (
             <button
               type="button"
               aria-label={node.expanded ? 'Collapse' : 'Expand'}


### PR DESCRIPTION
Adding `asyncChildren` flag in the node object will allow it to have a toggle button beside it. It is useful when you do not have the data when bootstrapping your tree 